### PR TITLE
make nsm.h (c)importable from zig

### DIFF
--- a/extras/nsm.h/nsm.h
+++ b/extras/nsm.h/nsm.h
@@ -488,10 +488,10 @@ NSM_EXPORT int _nsm_osc_open ( const char *path, const char *types, lo_arg **arg
 
     if ( r ) {
         if ( out_msg == NULL) {	
-    	  OSC_REPLY_ERR( r, "");
-    	else {
-    	  OSC_REPLY_ERR( r, out_msg);
-    	}
+            OSC_REPLY_ERR( r, "");
+        } else {
+            OSC_REPLY_ERR( r, out_msg);
+        }
     }
     else
         OSC_REPLY( "OK" );
@@ -520,10 +520,10 @@ NSM_EXPORT int _nsm_osc_save ( const char *path, const char *types, lo_arg **arg
 
     if ( r ) {
         if ( out_msg == NULL) {	
-    	  OSC_REPLY_ERR( r, "");
-    	else {
-    	  OSC_REPLY_ERR( r, out_msg);
-    	}
+            OSC_REPLY_ERR( r, "");
+        } else {
+            OSC_REPLY_ERR( r, out_msg);
+        }
     }
     else
         OSC_REPLY( "OK" );

--- a/extras/nsm.h/nsm.h
+++ b/extras/nsm.h/nsm.h
@@ -486,8 +486,13 @@ NSM_EXPORT int _nsm_osc_open ( const char *path, const char *types, lo_arg **arg
 
     int r = nsm->open( &argv[0]->s, &argv[1]->s, &argv[2]->s, &out_msg, nsm->open_userdata );
 
-    if ( r )
-        OSC_REPLY_ERR( r, ( out_msg ? out_msg : "") );
+    if ( r ) {
+        if ( out_msg == NULL) {	
+    	  OSC_REPLY_ERR( r, "");
+    	else {
+    	  OSC_REPLY_ERR( r, out_msg);
+    	}
+    }
     else
         OSC_REPLY( "OK" );
 
@@ -513,8 +518,13 @@ NSM_EXPORT int _nsm_osc_save ( const char *path, const char *types, lo_arg **arg
 
     int r = nsm->save(&out_msg, nsm->save_userdata );
 
-    if ( r )
-        OSC_REPLY_ERR( r, ( out_msg ? out_msg : "") );
+    if ( r ) {
+        if ( out_msg == NULL) {	
+    	  OSC_REPLY_ERR( r, "");
+    	else {
+    	  OSC_REPLY_ERR( r, out_msg);
+    	}
+    }
     else
         OSC_REPLY( "OK" );
 


### PR DESCRIPTION
The zig cImport feature is not happy with the line  `OSC_REPLY_ERR( r, ( out_msg ? out_msg : "") );` because out_msg is a string list and "" is just a string. It's legal c as both things are just a pointer, but zig understands this type mismatch.